### PR TITLE
Add Mempool to Relay

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,16 +8,31 @@
       "name": "@flashbake/core",
       "version": "0.0.1",
       "license": "Apache 2.0",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
       "devDependencies": {
+        "@types/lodash": "^4.14.177",
         "@types/node": "^16.11.7",
         "typescript": "^4.4.4"
       }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.177",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.177.tgz",
+      "integrity": "sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "16.11.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.9.tgz",
       "integrity": "sha512-MKmdASMf3LtPzwLyRrFjtFFZ48cMf8jmX5VRYrDQiJa8Ybu5VAmkqBWqKU8fdCwD8ysw4mQ9nrEHvzg6gunR7A==",
       "dev": true
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/typescript": {
       "version": "4.5.2",
@@ -34,11 +49,22 @@
     }
   },
   "dependencies": {
+    "@types/lodash": {
+      "version": "4.14.177",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.177.tgz",
+      "integrity": "sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw==",
+      "dev": true
+    },
     "@types/node": {
       "version": "16.11.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.9.tgz",
       "integrity": "sha512-MKmdASMf3LtPzwLyRrFjtFFZ48cMf8jmX5VRYrDQiJa8Ybu5VAmkqBWqKU8fdCwD8ysw4mQ9nrEHvzg6gunR7A==",
       "dev": true
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "typescript": {
       "version": "4.5.2",

--- a/core/package.json
+++ b/core/package.json
@@ -1,18 +1,26 @@
 {
   "name": "@flashbake/core",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Core components for Flashbake infrastructure",
-  "main": "index.js",
+  "main": "build/src/index.js",
+  "files": [
+    "build/**/*",
+    "src/**/*"
+  ],
   "scripts": {
     "build": "npx tsc -d",
+    "prepublishOnly": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
   "author": "Flashbake Team",
   "license": "Apache 2.0",
   "devDependencies": {
+    "@types/lodash": "^4.14.177",
     "@types/node": "^16.11.7",
     "typescript": "^4.4.4"
   },
-  "dependencies": {}
+  "dependencies": {
+    "lodash": "^4.17.21"
+  }
 }

--- a/core/src/bundle-utils.ts
+++ b/core/src/bundle-utils.ts
@@ -1,0 +1,18 @@
+import _ from "lodash"
+import { Bundle } from './types/bundle'
+
+/** Helper functions for working with `Bundle` objects */
+const BundleUtils = {
+  /**
+   * Determine if two `Bundle` objects are equal.
+   * 
+   * @param a The first `Bundle`
+   * @param b The second `Bundle`
+   * @returns A boolean indicating if the two `Bundle`s are equivalent.
+   */
+  isEqual: (a: Bundle, b: Bundle): boolean => {
+    return _.isEqual(a, b)
+  }
+}
+
+export default BundleUtils

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -6,3 +6,6 @@
 export { Bundle } from './types/bundle'
 export { Address, TransactionHash } from './types/core'
 export { TezosTransaction } from './types/tezos-transaction'
+
+// Classes
+export { default as BundleUtils } from './bundle-utils'

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -10,7 +10,8 @@
     "removeComments": true,
     "strict": true,
     "resolveJsonModule": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "declaration": true
   },
   "include": [
     "src/*.ts"

--- a/relay/package-lock.json
+++ b/relay/package-lock.json
@@ -8,16 +8,37 @@
       "name": "@flashbake/relay",
       "version": "0.0.1",
       "license": "Apache 2.0",
+      "dependencies": {
+        "@flashbake/core": "^0.0.1",
+        "lodash": "^4.17.21"
+      },
       "devDependencies": {
+        "@types/lodash": "^4.14.177",
         "@types/node": "^16.11.7",
         "typescript": "^4.4.4"
       }
+    },
+    "node_modules/@flashbake/core": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@flashbake/core/-/core-0.0.1.tgz",
+      "integrity": "sha512-T4EIZAFWTzxKAidt00LdYOaRD+qSlaai8Ms3X7bGcveh57Ir7mjAZ/XXvftotOWrz6XwLEIVwZXpZBSIEJwavQ=="
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.177",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.177.tgz",
+      "integrity": "sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "16.11.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.9.tgz",
       "integrity": "sha512-MKmdASMf3LtPzwLyRrFjtFFZ48cMf8jmX5VRYrDQiJa8Ybu5VAmkqBWqKU8fdCwD8ysw4mQ9nrEHvzg6gunR7A==",
       "dev": true
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/typescript": {
       "version": "4.5.2",
@@ -34,11 +55,27 @@
     }
   },
   "dependencies": {
+    "@flashbake/core": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@flashbake/core/-/core-0.0.1.tgz",
+      "integrity": "sha512-T4EIZAFWTzxKAidt00LdYOaRD+qSlaai8Ms3X7bGcveh57Ir7mjAZ/XXvftotOWrz6XwLEIVwZXpZBSIEJwavQ=="
+    },
+    "@types/lodash": {
+      "version": "4.14.177",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.177.tgz",
+      "integrity": "sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw==",
+      "dev": true
+    },
     "@types/node": {
       "version": "16.11.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.9.tgz",
       "integrity": "sha512-MKmdASMf3LtPzwLyRrFjtFFZ48cMf8jmX5VRYrDQiJa8Ybu5VAmkqBWqKU8fdCwD8ysw4mQ9nrEHvzg6gunR7A==",
       "dev": true
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "typescript": {
       "version": "4.5.2",

--- a/relay/package.json
+++ b/relay/package.json
@@ -11,8 +11,12 @@
   "author": "Flashbake Team",
   "license": "Apache 2.0",
   "devDependencies": {
+    "@types/lodash": "^4.14.177",
     "@types/node": "^16.11.7",
     "typescript": "^4.4.4"
   },
-  "dependencies": {}
+  "dependencies": {
+    "@flashbake/core": "^0.0.2",
+    "lodash": "^4.17.21"
+  }
 }

--- a/relay/src/implementations/in-memory/in-memory-mempool.ts
+++ b/relay/src/implementations/in-memory/in-memory-mempool.ts
@@ -1,0 +1,70 @@
+import Mempool from "../../interfaces/mempool"
+import { Bundle, BundleUtils } from "@flashbake/core"
+import _ from 'lodash'
+
+/** 
+ * A Mempool that exists in memory. 
+ *
+ * This implementation has minimal dependencies and logic, however it is volatile and will not persist data between 
+ * runs. 
+ */
+export default class InMemoryMempool implements Mempool {
+  /**
+   * Bundles waiting for submission. 
+   * 
+   * TODO(keefertaylor): Consider using a Set for better performance, deferring this because I'm not sure how Sets do
+   *                     object equality in Typescript.
+   */
+  private readonly bundles: Array<Bundle>
+
+  /** Create a new InMemoryMempool */
+  public constructor() {
+    this.bundles = []
+  }
+
+  /** Mempool Interface */
+
+  public addBundle(bundle: Bundle): Promise<boolean> {
+    // Do not add duplicate operations
+    if (this.contains(bundle)) {
+      return Promise.resolve(false)
+    }
+
+    // Otherwise add a Bundle.
+    this.bundles.push(bundle)
+    return Promise.resolve(true)
+  }
+
+  getBundles(): Promise<Array<Bundle>> {
+    return Promise.resolve(_.cloneDeep(this.bundles))
+  }
+
+  removeBundle(bundleToRemove: Bundle): Promise<boolean> {
+    // Capture the old size of the Mempool
+    const oldLength = this.bundles.length
+
+    // Remove any matching objects.
+    const newArray = _.remove(this.bundles, (bundle: Bundle) => {
+      return _.isEqual(bundle, bundleToRemove)
+    })
+
+    // Compare lengths to figure out if the item existed.
+    return Promise.resolve(oldLength !== newArray.length)
+  }
+
+  /** Helper Methods */
+
+  /** 
+   * Determine if the Mempool contains the given `Bundle`.
+   * 
+   * @param needle The `Bundle` to search for.
+   * @returns A boolean indicating if the bundle was in the Mempool.
+   */
+  private contains(needle: Bundle): boolean {
+    const result = _.find(this.bundles, (bundle: Bundle) => {
+      return BundleUtils.isEqual(bundle, needle)
+    })
+    return result !== undefined
+  }
+
+}

--- a/relay/src/interfaces/mempool.ts
+++ b/relay/src/interfaces/mempool.ts
@@ -1,0 +1,31 @@
+import { Bundle } from '@flashbake/core'
+
+/**
+ * A pool of pending bundles to be placed in Flashback.
+ * 
+ * TODO(keefertaylor): It is unclear what identifiers should exist here. How do we do `Bundle` equality checks.
+ */
+export default interface Mempool {
+  /** 
+   * Add a `Bundle` to the pool. 
+   *
+   * @param bundle The bundle to add.
+   * @returns A boolean indicating whether the given `Bundle` was accepted. 
+   */
+  addBundle(bundle: Bundle): Promise<boolean>
+
+  /** 
+   * Retrieve a list of `Bundle`s in the pool.
+   * 
+   * @returns An array of `Bundle`s in the pool.
+   */
+  getBundles(): Promise<Array<Bundle>>
+
+  /** 
+   * Remove a `Bundle` from the pool. 
+   *
+   * @param bundle The `Bundle` to remove
+   * @returns A boolean indicating whether the `Bundle` was removed. 
+   */
+  removeBundle(bundle: Bundle): Promise<boolean>
+}

--- a/relay/tsconfig.json
+++ b/relay/tsconfig.json
@@ -14,5 +14,5 @@
   },
   "include": [
     "src/*.ts"
-  ]
+, "src/implementations/in-memory/in-memory-mempool.ts", "src/interfaces/mempool.ts"  ]
 }


### PR DESCRIPTION
Add mempool services to the `Relay` component.  The mempool is meant to serve as a persistent pool of `Bundle` objects that are waiting to be submitted to a baker. It is likely the mempool API will need to evolve over time.

Specifically:
- Add `Mempool`: An interface that defines a Mempool and allows us to have multiple implementations (in-memory, DB backed) and fakes for tests
- Add `InMemoryMempool`: An volatile implementation of `Mempool` that is only held in memory.

As part of this, export a new `BundleUtils` object from `@flashbake/core`.