### PR TITLE
Add a Registry Service 

### DIFF
--- a/relay/src/implementations/in-memory/in-memory-mempool.ts
+++ b/relay/src/implementations/in-memory/in-memory-mempool.ts
@@ -35,11 +35,11 @@ export default class InMemoryMempool implements Mempool {
     return Promise.resolve(true)
   }
 
-  getBundles(): Promise<Array<Bundle>> {
+  public getBundles(): Promise<Array<Bundle>> {
     return Promise.resolve(_.cloneDeep(this.bundles))
   }
 
-  removeBundle(bundleToRemove: Bundle): Promise<boolean> {
+  public removeBundle(bundleToRemove: Bundle): Promise<boolean> {
     // Capture the old size of the Mempool
     const oldLength = this.bundles.length
 

--- a/relay/src/implementations/in-memory/in-memory-registry-service.ts
+++ b/relay/src/implementations/in-memory/in-memory-registry-service.ts
@@ -1,0 +1,67 @@
+import { RegistryService } from "../../interfaces/registry-service";
+import { Address } from "@flashbake/core";
+
+/**
+ * An implementation of RegistryService which holds the mapping in memory.
+ * 
+ * This implementation has minimal dependencies and logic, however it is volatile and will not persist data between 
+ * runs.
+ */
+export default class InMemoryRegistryService implements RegistryService {
+  /** Whether the registry service is initialized. */
+  private initialized: boolean
+
+  /** Baker mapping from public key hash to endpoint. */
+  private readonly bakerMapping: Map<Address, string>
+
+  /**
+   * Create a new InMemoryRegistryService.
+   * 
+   * The service will automatically start initialization.
+   * 
+   * @param bigMapId The identifier number of the registry's big map.
+   */
+  public constructor(private readonly bigMapId: number) {
+    // Set to be unitialized at construction time.
+    this.initialized = false
+    this.bakerMapping = new Map<Address, string>()
+
+    // Kick off an initilization
+    this.initialize()
+  }
+
+  /** RegistryService interface */
+
+  public isInititalized(): Promise<boolean> {
+    return Promise.resolve(this.initialized)
+  }
+
+  public async initialize(): Promise<void> {
+    // If initialization already happened, warn and  do nothing.
+    if (this.initialized) {
+      console.warn("Warning: InMemoryRegistryService is already initialized. This call is a no-op.")
+      return
+    }
+
+    // Refresh the registry and update the initialization state when complete.
+    await this.refresh()
+    this.initialized = true
+  }
+
+  // TODO(keefertaylor): Implement
+  refresh(): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+
+  isRegistered(baker: Address): Promise<boolean> {
+    return Promise.resolve(this.bakerMapping.has(baker))
+  }
+
+  getEndpoint(baker: Address): Promise<string> {
+    // Return undefined if the baker is not known.
+    if (this.isRegistered(baker)) {
+      return undefined
+    }
+    return this.bakerMapping[baker]
+  }
+}

--- a/relay/src/implementations/in-memory/in-memory-registry-service.ts
+++ b/relay/src/implementations/in-memory/in-memory-registry-service.ts
@@ -18,10 +18,8 @@ export default class InMemoryRegistryService implements RegistryService {
    * Create a new InMemoryRegistryService.
    * 
    * The service will automatically start initialization.
-   * 
-   * @param bigMapId The identifier number of the registry's big map.
    */
-  public constructor(private readonly bigMapId: number) {
+  public constructor() {
     // Set to be unitialized at construction time.
     this.initialized = false
     this.bakerMapping = new Map<Address, string>()

--- a/relay/src/interfaces/registry-service.ts
+++ b/relay/src/interfaces/registry-service.ts
@@ -1,0 +1,37 @@
+import { Address } from "@flashbake/core"
+
+/** Defines a registry service that can read the Flashbake Registry from an onchain contract */
+export interface RegistryService {
+  /** 
+   * Determine whether the registry service has been initialized.
+   * 
+   * @returns A boolean indicating if the service is initialized.
+   */
+  isInititalized(): Promise<boolean>
+
+  /**
+   * Initialize the service.
+   */
+  initialize(): Promise<void>
+
+  /**
+   * Refresh the contracts from the registry.
+   */
+  refresh(): Promise<void>
+
+  /**
+   * Check if the given address is registered.
+   * 
+   * @param baker The baker to check.
+   * @returns A boolean indicating if the baker is registered.
+   */
+  isRegistered(baker: Address): Promise<boolean>
+
+  /**
+   * Return an endpoint for the given baker.
+   * 
+   * @param baker The baker to query.
+   * @returns A url for the baker's endpoint if it exists in the registry, otherwise undefined.
+   */
+  getEndpoint(baker: Address): Promise<string>
+}


### PR DESCRIPTION
Adds an interface and partial implementation for `RegistryService`, a service which can read values from the on-chain Flashbake Registry.

Adds:
`RegistryService`: An interface defining a registry service
`InMemoryFlashbakeRegistry`: An implementation of `RegistryService` which holds the registry in memory