### PR TITLE
Add `Network` Enum

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@flashbake/core",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@flashbake/core",
-      "version": "0.0.1",
-      "license": "Apache 2.0",
+      "version": "0.0.3",
+      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"
       },

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flashbake/core",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Core components for Flashbake infrastructure",
   "main": "build/src/index.js",
   "files": [

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -9,3 +9,4 @@ export { TezosTransaction } from './types/tezos-transaction'
 
 // Classes
 export { default as BundleUtils } from './bundle-utils'
+export { default as Network } from './network'

--- a/core/src/network.ts
+++ b/core/src/network.ts
@@ -1,0 +1,8 @@
+/**
+ * Networks available for Flashbake.
+ */
+enum Network {
+  Granadanet,
+  Mainnet
+}
+export default Network

--- a/relay/package-lock.json
+++ b/relay/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@flashbake/core": "^0.0.2",
+        "@flashbake/core": "^0.0.3",
         "@taquito/taquito": "^11.0.1",
         "axios": "^0.24.0",
         "lodash": "^4.17.21"
@@ -21,9 +21,9 @@
       }
     },
     "node_modules/@flashbake/core": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@flashbake/core/-/core-0.0.2.tgz",
-      "integrity": "sha512-A71UR1+ukl6Zy9SYk7Z5aIzhm4MZb9h6ZEtJvQuiDoFt5H3c2eA3E4M5cJw8gI+KsPOl5GS75C2iIXBhwri+EA==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@flashbake/core/-/core-0.0.3.tgz",
+      "integrity": "sha512-a61vlfbXOWfL4iInMxns32V9NvMlYXUCCBfG/MOxPCF5PbTvDitmmgqUDHJNIJ09zfHpn/0Fy8ILUwzpPjPLtg==",
       "dependencies": {
         "lodash": "^4.17.21"
       }
@@ -563,9 +563,9 @@
   },
   "dependencies": {
     "@flashbake/core": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@flashbake/core/-/core-0.0.2.tgz",
-      "integrity": "sha512-A71UR1+ukl6Zy9SYk7Z5aIzhm4MZb9h6ZEtJvQuiDoFt5H3c2eA3E4M5cJw8gI+KsPOl5GS75C2iIXBhwri+EA==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@flashbake/core/-/core-0.0.3.tgz",
+      "integrity": "sha512-a61vlfbXOWfL4iInMxns32V9NvMlYXUCCBfG/MOxPCF5PbTvDitmmgqUDHJNIJ09zfHpn/0Fy8ILUwzpPjPLtg==",
       "requires": {
         "lodash": "^4.17.21"
       }

--- a/relay/package.json
+++ b/relay/package.json
@@ -16,7 +16,7 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
-    "@flashbake/core": "^0.0.2",
+    "@flashbake/core": "^0.0.3",
     "@taquito/taquito": "^11.0.1",
     "axios": "^0.24.0",
     "lodash": "^4.17.21"

--- a/relay/src/implementations/tzkt/tzkt-indexer-service.ts
+++ b/relay/src/implementations/tzkt/tzkt-indexer-service.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import IndexerService from '../../interfaces/indexer-service'
+import { Network } from '@flashbake/core'
 
 /**
  * The type of an object returned by the TzKt API
@@ -24,12 +25,24 @@ type BigMapResponse = {
  * TODO(keefertaylor): Implement the concepts of network selection and automatically resolve base url.
  */
 export default class TzKtIndexerService implements IndexerService {
+  /** The base URL for API requests */
+  private readonly baseUrl: string
+
   /**
    * Create a new TzKtIndexerService.
    * 
-   * @param baseUrl The base URL of the API. Defaults to mainnet.
+   * @param network The network the indexer is used on.
    */
-  public constructor(private readonly baseUrl: string = "https://api.tzkt.io/v1") { }
+  public constructor(network: Network) {
+    switch (network) {
+      case Network.Granadanet:
+        this.baseUrl = "https://api.granadanet.tzkt.io/"
+        break
+      case Network.Mainnet:
+        this.baseUrl = "https://api.tzkt.io/v1"
+        break
+    }
+  }
 
   /** IndexerService Interface */
 

--- a/relay/src/test-drivers/test-maps.ts
+++ b/relay/src/test-drivers/test-maps.ts
@@ -1,7 +1,8 @@
 /** Simple tes driver for maps */
 
-import TzktIndexerService from './implementations/tzkt/tzkt-indexer-service'
-import TaquitoRpcService from './implementations/taquito/taquito-rpc-service'
+import { Network } from '@flashbake/core'
+import TzktIndexerService from '../implementations/tzkt/tzkt-indexer-service'
+import TaquitoRpcService from '../implementations/taquito/taquito-rpc-service'
 
 const main = async () => {
   console.log("Resolving a balance from the kUSD contract...")
@@ -11,7 +12,7 @@ const main = async () => {
 
   const nodeUrl = "https://mainnet.smartpy.io"
   const baseUrl = "https://api.tzkt.io/v1"
-  const rpc = new TzktIndexerService(baseUrl)
+  const rpc = new TzktIndexerService(Network.Mainnet)
   const taquito = new TaquitoRpcService(nodeUrl)
 
   const bigMapId = await taquito.getBigMapIdentifier(contractAddress, annotation)


### PR DESCRIPTION
Add a `Network` enum in `@flashbake/core` and use it to configure the `TzKt` indexing service in the `@flashbake/relay` package. 

Cut a new release (v0.0.3) of `@flashbake/core` and publish offline to make CI tests pass for this PR. 