### PR TITLE
Mainnet fixes

### DIFF
--- a/relay/package-lock.json
+++ b/relay/package-lock.json
@@ -19,11 +19,12 @@
         "express": "^4.17.2",
         "http-proxy-middleware": "^2.0.1",
         "lodash": "^4.17.21",
+        "p-limit": "^3.1.0",
         "prom-client": "^14.0.1",
         "yargs": "^17.5.1"
       },
       "bin": {
-        "baker-endpoint": "build/src/app.js"
+        "flashbake-relay": "build/src/app.js"
       },
       "devDependencies": {
         "@types/express": "^4.17.13",
@@ -1229,6 +1230,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1674,6 +1689,17 @@
       "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   },
@@ -2616,6 +2642,14 @@
         "ee-first": "1.1.1"
       }
     },
+    "p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "requires": {
+        "yocto-queue": "^0.1.0"
+      }
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2932,6 +2966,11 @@
       "version": "21.0.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
       "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/relay/package.json
+++ b/relay/package.json
@@ -34,6 +34,7 @@
     "express": "^4.17.2",
     "http-proxy-middleware": "^2.0.1",
     "lodash": "^4.17.21",
+    "p-limit": "^3.1.0",
     "prom-client": "^14.0.1",
     "yargs": "^17.5.1"
   }

--- a/relay/src/http-relay.ts
+++ b/relay/src/http-relay.ts
@@ -212,7 +212,7 @@ export default class HttpRelay implements BlockObserver {
 
           // Remove any bundles found on-chain from pending resend queue
           if (this.bundles.delete(operation.hash)) {
-            console.info(`Relayed bundle identified by operation hash ${operation.hash} found on-chain.`);
+            console.info(`Relayed bundle identified by operation hash ${operation.hash} found on - chain.`);
             console.debug(`${this.bundles.size} bundles remain pending.`);
 
             // update metrics
@@ -248,7 +248,7 @@ export default class HttpRelay implements BlockObserver {
   private injectionHandler(req: Request, res: Response) {
     const transaction = JSON.parse(req.body);
     console.log("Flashbake transaction received from client");
-    // console.debug(`Hex-encoded transaction content: ${transaction}`);
+    // console.debug(`Hex - encoded transaction content: ${ transaction }`);
 
     // update relevant metrics
     this.metricReceivedBundlesTotal.inc();

--- a/relay/src/http-relay.ts
+++ b/relay/src/http-relay.ts
@@ -186,11 +186,13 @@ export default class HttpRelay implements BlockObserver {
         relayReq.write(bundleStr);
         relayReq.end();
       }).catch((reason) => {
+        // When no flashbaker is found, we drop the bundle.
         console.log(`Flashbaker URL not found in the registry: ${reason}`);
+        this.bundles.delete(opHash);
         if (res) {
           res.status(500)
             .contentType('text/plain')
-            .send('No flashbakers available for the remaining period this cycle.');
+            .send('No flashbakers available in the next 15 blocks, please try again later.');
         }
       })
     }).catch((reason) => {

--- a/relay/src/http-relay.ts
+++ b/relay/src/http-relay.ts
@@ -90,12 +90,8 @@ export default class HttpRelay implements BlockObserver {
         // console.debug(`Analyzing baker address ${baker.delegate}`);
 
         // Fitting baker must still be in the future and within a certain cutoff buffer period.
-        // FIXME: time to live is set to 15 instead of 120. Assuming that the user does not care
-        // if the operation is not included within 7 minutes.
-        // This allows to query the registry within one block.
-        // const timeToLive = this.maxOperationsTimeToLive
-        const timeToLive = 15;
-        if ((baker.level > this.lastBlockLevel) && (baker.level <= this.lastBlockLevel + timeToLive) && (baker.round == 0) &&
+        // It must also be before the operation's time to live (120 blocks on mainnet)
+        if ((baker.level > this.lastBlockLevel) && (baker.level <= this.lastBlockLevel + this.maxOperationsTimeToLive) && (baker.round == 0) &&
           (this.lastBlockTimestamp + ((baker.level - this.lastBlockLevel) * this.blockInterval) > (Date.now() + this.cutoffInterval))) {
           try {
             const address = baker.delegate;
@@ -192,7 +188,7 @@ export default class HttpRelay implements BlockObserver {
         if (res) {
           res.status(500)
             .contentType('text/plain')
-            .send('No flashbakers available in the next 15 blocks, please try again later.');
+            .send(`No flashbakers available in the next ${this.maxOperationsTimeToLive} blocks, please try again later.`);
         }
       })
     }).catch((reason) => {

--- a/relay/src/http-relay.ts
+++ b/relay/src/http-relay.ts
@@ -96,7 +96,7 @@ export default class HttpRelay implements BlockObserver {
           try {
             const address = baker.delegate;
             let endpoint = await this.registry.getEndpoint(address);
-            console.debug(`Baker ${address} has baking rights at round ${baker.round} for level ${baker.level} estimated to bake at ${baker.estimated_time}, registered endpoint URL ${endpoint}`);
+            //console.debug(`Baker ${address} has baking rights at round ${baker.round} for level ${baker.level} estimated to bake at ${baker.estimated_time}, registered endpoint URL ${endpoint}`);
 
             if (endpoint) {
               console.debug(`Found endpoint ${endpoint} for baker ${address} in flashbake registry.`);

--- a/relay/src/implementations/in-memory/caching-baking-rights-service.ts
+++ b/relay/src/implementations/in-memory/caching-baking-rights-service.ts
@@ -30,12 +30,12 @@ export default class CachingBakingRightsService implements BakingRightsService, 
   }
 
   public constructor(
-      private readonly rpcApiUrl: string,
-      private readonly cycleMonitor: CycleMonitor,
-      private maxRound = 0
+    private readonly rpcApiUrl: string,
+    private readonly cycleMonitor: CycleMonitor,
+    private maxRound = 0
   ) {
     cycleMonitor.addObserver(this);
-    this.innerBakingRightsService = new RpcBakingRightsService(rpcApiUrl);
+    this.innerBakingRightsService = new RpcBakingRightsService(rpcApiUrl, cycleMonitor);
     this.innerBakingRightsService.setMaxRound(maxRound);
   };
 }

--- a/relay/src/implementations/in-memory/generic-cycle-monitor.ts
+++ b/relay/src/implementations/in-memory/generic-cycle-monitor.ts
@@ -7,8 +7,8 @@ import ConstantsUtil from "implementations/rpc/rpc-constants";
 export default class GenericCycleMonitor implements CycleMonitor, BlockObserver {
   private observers = new Set<CycleObserver>();
   private lastCycle = -1;
-  private blocksPerCycle = 0;
-  private chainId = "main";
+  public blocksPerCycle = 0;
+  public chainId = "main";
   private readonly blocksBeforeGranada = 1589248;
   private readonly cyclesBeforeGranada = 388;
 

--- a/relay/src/implementations/rpc/rpc-baking-rights-service.ts
+++ b/relay/src/implementations/rpc/rpc-baking-rights-service.ts
@@ -34,8 +34,8 @@ export default class RpcBakingRightsService implements BakingRightsService {
   private static getBakingRights(rpcApiUrl: string, cycle: number, cycleMonitor: CycleMonitor, maxRound: number): Promise<BakingAssignment[]> {
     let bakingAssignments: Promise<BakingAssignment>[] = [];
 
-    // Fetching baking rights for thousand of levels concurrently with a maximum request count of 5.
-    const limit = pLimit(5);
+    // Fetching baking rights for thousand of levels concurrently with a maximum request count of 20.
+    const limit = pLimit(20);
     const [startLevel, endLevel] = RpcBakingRightsService.getStartEndLevel(cycle, cycleMonitor);
     for (let i = startLevel; i < endLevel; i++) {
       bakingAssignments.push(

--- a/relay/src/interfaces/cycle-monitor.ts
+++ b/relay/src/interfaces/cycle-monitor.ts
@@ -15,6 +15,8 @@ export interface CycleObserver {
  * A service to monitor new cycles and notify the registered observers.
  */
 export default interface CycleMonitor {
+  chainId: string;
+  blocksPerCycle: number;
   /** 
    * Add a new cycle observer.
    */
@@ -23,7 +25,7 @@ export default interface CycleMonitor {
   /** 
    * Remove a previously added cycle observer.
    */
-   removeObserver(observer: CycleObserver): void;
+  removeObserver(observer: CycleObserver): void;
 }
 
 


### PR DESCRIPTION
While flashbake has been working smoothly on ghostnet for 2 months, these two band-aids are needed for mainnet to work.

## Rights query issue

Querying baking rights for an entire cycle is known to freeze the node and there is [no current plan to fix](https://gitlab.com/tezos/tezos/-/issues/1614#note_650444912). Deploying mainnet relay in MIDL infra indeed causes unacceptable slowdowns on the nodes. The recommended workaround is to query every level so I did that. Now, when the relay starts, it sends 16k http requests to the node to query rights for the current cycle and the next.

This required some extra code to calculate the first and last block of cycles on mainnet (this calculation on mainnet is more complex than on testnets due to history of cycle length change).

But I reliazed there is no real need for flashbake relay to be aware of "cycles" at all: all it needs is a view on the next 120 blocks (and perhaps a few more) in order to work properly. Therefore, I envision a complete removal of the cycle logic and implementation of a more nimble way of collecting future baking rights on a rolling basis.

A new library "f-limit" was added in order to limit the number of concurrent calls.

## Registry query issue

The next problem was in `findNextFlashbakerUrl`. This function takes all baking rights from the next block to the end of the cycle and queries the registry for a URL until it finds one.

On ghostnet there is always a flashbaker soon, but on mainnet, only one baker is there, so it's typical to be hours away from a flashbaker.

Mainnet is always slower.... one registry query takes about one second, so the loop never finishes. Besides, after a new block comes and the operation is not included, another thread starts querying again. So, we end up with a lot of registry queries, the transaction never completes, never flushes the flashbake pool (until the end of the cycle I guess) and the user is left hanging.

Solution: gather the `max_operation_time_to_live` from chain (which on mainnet is 120) and use it as an upper bound of the blocks for which we scour for flashbake endpoint addresses on-chain. And, when none is found, return immediately with a helpful error message.

It makes sense: if there is no flashbaker in the next 120 blocks, then no flashbaker will be able to insert your operation before it expires, so it makes sense to abort straight away (this fixes https://github.com/flashbake/prototype/issues/28)

I still have to verify that it works, but it should (I'm waiting for tessellated geometry baker's turn to bake). Querying 120 bakers takes 1-2 minutes, during this time, 3 or 4 blocks go by and trigger more queries until the first batch completes and the operation is pruned from the flashbake mempool. So it's not ideal but it works and it's minimally invasive in the current codebase.

To do better, we need to:
* not query twice the same baker for the same block (it's very likely that the list of bakers of the next 120 blocks will be smaller than 120)
* either query the registry endpoints on a schedule and cache them, or maintain a live list by scanning at start time, then monitoing the blocks for changes to the registry contract