### PR TITLE
No cycles

### DIFF
--- a/relay/src/app.ts
+++ b/relay/src/app.ts
@@ -22,8 +22,7 @@ async function startRelay(port: number, rpcApiUrl: string, registryContract: str
   // Read all rights for the cycle
   const blockMonitor = new RpcBlockMonitor(rpcApiUrl)
   const bakingRightsService = new CachingBakingRightsService(
-    rpcApiUrl,
-    new RpcCycleMonitor(rpcApiUrl, blockMonitor),
+    rpcApiUrl
   )
 
   const rpcService = new TaquitoRpcService(rpcApiUrl);

--- a/relay/src/implementations/rpc/rpc-baking-rights-service.ts
+++ b/relay/src/implementations/rpc/rpc-baking-rights-service.ts
@@ -1,7 +1,5 @@
 import BakingRightsService, { BakingAssignment } from "../../interfaces/baking-rights-service"
-import CycleMonitor from "../../interfaces/cycle-monitor"
 import * as http from "http";
-import pLimit from "p-limit";
 
 /** 
  * A baking rights service that queries an RPC endpoint for each baking rights retrieval request.
@@ -10,38 +8,15 @@ export default class RpcBakingRightsService implements BakingRightsService {
   private cycle = 0;
   private maxRound = 0;
 
-  setCycle(cycle: number) {
-    this.cycle = cycle;
-  }
-
   setMaxRound(maxRound: number) {
     this.maxRound = maxRound;
   }
 
-  private static getStartEndLevel(cycle: number, cycleMonitor: CycleMonitor): [number, number] {
-    const blocksPerCycle = cycleMonitor.blocksPerCycle;
-    if (cycleMonitor.chainId == "NetXdQprcVkpaWU") {
-      // tezos mainnet - blocks per cycle changed in granada
-      const blocksBeforeGranada = 1589248;
-      const cyclesAfterGranada = cycle - 388;
-      return [blocksBeforeGranada + cyclesAfterGranada * blocksPerCycle, blocksBeforeGranada + (cyclesAfterGranada + 1) * blocksPerCycle - 1];
-    } else {
-      return [cycle * blocksPerCycle, (cycle + 1) * blocksPerCycle - 1];
-    }
-  }
 
-
-  private static getBakingRights(rpcApiUrl: string, cycle: number, cycleMonitor: CycleMonitor, maxRound: number): Promise<BakingAssignment[]> {
+  private static getBakingRights(rpcApiUrl: string, level: number, maxRound: number): Promise<BakingAssignment[]> {
     let bakingAssignments: Promise<BakingAssignment>[] = [];
 
-    // Fetching baking rights for thousand of levels concurrently with a maximum request count of 20.
-    const limit = pLimit(20);
-    const [startLevel, endLevel] = RpcBakingRightsService.getStartEndLevel(cycle, cycleMonitor);
-    for (let i = startLevel; i < endLevel; i++) {
-      bakingAssignments.push(
-        limit(() => RpcBakingRightsService.getBakingRightForLevel(rpcApiUrl, i, maxRound))
-      )
-    }
+    bakingAssignments = [RpcBakingRightsService.getBakingRightForLevel(rpcApiUrl, level, maxRound)]
     return Promise.all(bakingAssignments)
   }
 
@@ -69,9 +44,7 @@ export default class RpcBakingRightsService implements BakingRightsService {
             reject(error.message);
             return;
           } else try {
-            if (level % 100 === 0) {
-              console.log(`Fetched baking right for level ${level}`);
-            }
+            console.log(`Fetched baking right for level ${level}`);
             resolve(JSON.parse(rawData)[0] as BakingAssignment);
             return;
           } catch (e) {
@@ -91,18 +64,15 @@ export default class RpcBakingRightsService implements BakingRightsService {
    * 
    * @returns Addresses of the bakers assigned in the current cycle in the order of their assignment
    */
-  public getBakingRights(): Promise<BakingAssignment[]> {
+  public getBakingRights(level: number): Promise<BakingAssignment[]> {
     return new Promise<BakingAssignment[]>((resolve, reject) => {
       Promise.all([
-        RpcBakingRightsService.getBakingRights(this.rpcApiUrl, this.cycle, this.cycleMonitor, this.maxRound),
-        RpcBakingRightsService.getBakingRights(this.rpcApiUrl, this.cycle + 1, this.cycleMonitor, this.maxRound)
-      ]).then((cycleRights) => {
-        resolve(cycleRights[0].concat(cycleRights[1]));
-      }).catch((reason) => {
+        RpcBakingRightsService.getBakingRights(this.rpcApiUrl, level, this.maxRound),
+      ]).catch((reason) => {
         reject(reason);
       })
     });
   }
 
-  public constructor(private readonly rpcApiUrl: string, private readonly cycleMonitor: CycleMonitor) { }
+  public constructor(private readonly rpcApiUrl: string) { }
 }

--- a/relay/src/interfaces/baking-rights-service.ts
+++ b/relay/src/interfaces/baking-rights-service.ts
@@ -7,9 +7,10 @@ export default interface BakingRightsService {
   /** 
    * Retrieve baking rights.
    * 
-   * @returns An array of `BakingAssignment`s for a single baking cycle.
+   * @returns An array of `BakingAssignment`s for the relevant future
+   *          blocks after `level`.
    */
-  getBakingRights(): Promise<BakingAssignment[]>
+  getBakingRights(level: number): Promise<BakingAssignment[]>
 }
 
 /** 


### PR DESCRIPTION
In mumbai, the blocks per cycle will double and the block time will halve to 15 seconds. The number of blocks for which an operation is valid will also double, to 240. All constants will reflect this.

It never made sense to query blocks for the entire cycle. Whenever a flashbake transaction comes in, all that's matter is the next 120 (soon 240) blocks.

Therefore I want to refactor the cache system to:

* query the next 240 block production rights at boot time
* whenever a block N comes, query right for N + 240 and put it in the cache
* whenever a flashake transaction comes, cache should already be populated with relevant rights and next flashbaker instantly computed.

I already removed the entire cycle detection logic, because in this model, the relay no longer needs to be aware of cycles.

I am struggling a bit with the async programming style and wondering the following:

* in the caching system, should we index the rights by level?
* should the response of the caching system also be indexed by level?