### PR TITLE
Include all transactions into the block

### DIFF
--- a/baker-endpoint/src/http-baker-endpoint.ts
+++ b/baker-endpoint/src/http-baker-endpoint.ts
@@ -75,16 +75,16 @@ export default class HttpBakerEndpoint implements BlockObserver {
             parsedBundles.forEach(b => {
               let source: string = b.contents[0].source;
               if (source in bundlesSortedBySource) {
-                bundlesSortedBySource[source].push(b.contents);
+                bundlesSortedBySource[source].push(b);
               } else {
-                bundlesSortedBySource[source] = [b.contents];
+                bundlesSortedBySource[source] = [b];
               }
             })
-            let bundlesToInclude = bundlesSortedBySource.forEach((s: string, b: TezosParsedTransaction[]) => {
+            let bundlesToInclude: any[] = []
+            for (let s in bundlesSortedBySource) {
               // for now, we pick the first transaction per manager. Later, we could pick the highest fee one.
-              return b[0]
-            })
-
+              bundlesToInclude.push(bundlesSortedBySource[s][0]);
+            }
 
             console.debug("Exposing the following data to the external operations pool:");
             console.debug(JSON.stringify(bundlesToInclude, null, 2));


### PR DESCRIPTION
Previously we were running an auction to include only the transaction with the highest fee.

But because the flywheel sends transactions, and people are using both the flashabke.xyz relay and the baking bad relay, we often have several transactions in the flashbake endpoint's mempool.

Here we sort them to make sure we only include one transaction per manager per block, and we pass them all to the baker.

We will reintroduce auction later, but it will be opt-in. The bundle will have a flag `FIRST_OR_NOTHING` that indicates that it only wants to be included first, or not at all.